### PR TITLE
Add /status HTTP endpoint reporter and other improvements / fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
+FROM golang:alpine AS builder
+WORKDIR /workspace
+COPY . .
+RUN go build
+
+
 FROM alpine:latest
 
 COPY examples/selftest.json selftest.json
-COPY cerc /
+COPY --from=builder /workspace/cerc /
 
 ENTRYPOINT [ "/cerc" ]
 CMD [ "selftest.json" ]

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/32leaves/cerc
 go 1.12
 
 require (
+	github.com/jeremywohl/flatten v1.0.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/satori/go.uuid v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.12
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
+github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	"syscall"
 
 	"github.com/32leaves/cerc/pkg/cerc"
+	"github.com/32leaves/cerc/pkg/reporter/httpendpoint"
 	"github.com/32leaves/cerc/pkg/reporter/prometheus"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -41,8 +42,9 @@ import (
 type Config struct {
 	Service   cerc.Options `json:"service"`
 	Reporting struct {
-		Log        bool `json:"log,omitempty"`
-		Prometheus bool `json:"prometheus,omitempty"`
+		Log          bool `json:"log,omitempty"`
+		Prometheus   bool `json:"prometheus,omitempty"`
+		HTTPEndpoint bool `json:"httpEndpoint,omitempty"`
 	} `json:"reporting"`
 	PProf       bool `json:"pprof,omitempty"`
 	JSONLogging bool `json:"jsonLogging,omitempty"`
@@ -91,6 +93,11 @@ func main() {
 			log.WithError(err).Fatal("Prometheus reporter failed to start - exiting")
 			return
 		}
+		reporter = append(reporter, rep)
+	}
+	if cfg.Reporting.HTTPEndpoint {
+		rep := httpendpoint.NewReporter()
+		mux.HandleFunc("/status", rep.Serve)
 		reporter = append(reporter, rep)
 	}
 

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ type Config struct {
 }
 
 func main() {
-	if len(os.Args) < 2 {
+	if len(os.Args) < 2 || os.Args[1] == "-h" || os.Args[1] == "--help" || os.Args[1] == "help" {
 		log.Fatalf("usage: %s <config.json>", os.Args[0])
 	}
 

--- a/pkg/cerc/cerc.go
+++ b/pkg/cerc/cerc.go
@@ -60,7 +60,7 @@ type Pathway struct {
 		Request  Duration `json:"request,omitempty"`
 		Response Duration `json:"response,omitempty"`
 	} `json:"timeouts,omitempty"`
-	Period              Duration `json:"duration,omitempty"`
+	Period              Duration `json:"period,omitempty"`
 	TriggerOnly         bool     `json:"triggerOnly,omitempty"`
 	ResponseURLTemplate string   `json:"responseURLTemplate,omitempty"`
 }

--- a/pkg/cerc/cerc.go
+++ b/pkg/cerc/cerc.go
@@ -105,6 +105,7 @@ type Options struct {
 	DefaultPeriod       Duration   `json:"defaultPeriod"`
 	Auth                *BasicAuth `json:"auth,omitempty"`
 	ResponseURLTemplate string     `json:"responseURLTemplate,omitempty"`
+	FirstRunDelay       Duration   `json:"firstRunDelay"`
 }
 
 // fillInDefaults completes the options by setting default values if needed
@@ -166,6 +167,9 @@ type runner struct {
 func (r *runner) Run() {
 
 	// start with an inital run
+	if r.C.Config.FirstRunDelay > Duration(0*time.Second) {
+		time.Sleep(time.Duration(r.C.Config.FirstRunDelay))
+	}
 	go r.Probe()
 
 	// start ticker for subsequent runs

--- a/pkg/cerc/cerc.go
+++ b/pkg/cerc/cerc.go
@@ -198,9 +198,10 @@ func (r *runner) Probe() (*probe, error) {
 	responseURL, err := r.C.buildResponseURL(r.P.ResponseURLTemplate, r.P.Name, tkn)
 	if err != nil {
 		r.C.Reporter.ProbeFinished(Report{
-			Pathway: r.P.Name,
-			Result:  ProbeNonStarter,
-			Message: fmt.Sprintf("cannot build response URL: %v", err),
+			Pathway:   r.P.Name,
+			Result:    ProbeNonStarter,
+			Message:   fmt.Sprintf("cannot build response URL: %v", err),
+			Timestamp: time.Now(),
 		})
 		return nil, err
 	}
@@ -257,10 +258,11 @@ func (r *runner) failProbeIfUnresolved(tkn, reason string) {
 	r.mu.Unlock()
 
 	rep := Report{
-		Pathway:  r.P.Name,
-		Result:   ProbeFailure,
-		Message:  reason,
-		Duration: dur,
+		Pathway:   r.P.Name,
+		Result:    ProbeFailure,
+		Message:   reason,
+		Duration:  dur,
+		Timestamp: time.Now(),
 	}
 
 	p.Done(rep)
@@ -280,9 +282,10 @@ func (r *runner) Answer(tkn string) (ok bool) {
 
 	dur := time.Since(p.Started)
 	rep := Report{
-		Pathway:  r.P.Name,
-		Result:   ProbeSuccess,
-		Duration: dur,
+		Pathway:   r.P.Name,
+		Result:    ProbeSuccess,
+		Duration:  dur,
+		Timestamp: time.Now(),
 	}
 
 	p.Done(rep)
@@ -342,10 +345,11 @@ type Reporter interface {
 
 // Report reports the result of a probe
 type Report struct {
-	Pathway  string        `json:"pathway"`
-	Result   ProbeResult   `json:"result"`
-	Message  string        `json:"message,omitempty"`
-	Duration time.Duration `json:"duration,omitempty"`
+	Pathway   string        `json:"pathway"`
+	Result    ProbeResult   `json:"result"`
+	Message   string        `json:"message,omitempty"`
+	Duration  time.Duration `json:"duration,omitempty"`
+	Timestamp time.Time     `json:"timestamp,omitempty"`
 }
 
 // ProbeResult indicates the success of a pathway probe

--- a/pkg/reporter/httpendpoint/httpendpoint.go
+++ b/pkg/reporter/httpendpoint/httpendpoint.go
@@ -1,0 +1,80 @@
+package httpendpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/32leaves/cerc/pkg/cerc"
+	"github.com/jeremywohl/flatten"
+)
+
+// Reporter holds cerc reports in memory and serves them via HTTP
+type Reporter struct {
+	reports map[string]cerc.Report
+}
+
+// NewReporter constructs a new Reporter
+func NewReporter() *Reporter {
+	r := Reporter{}
+	r.reports = make(map[string]cerc.Report)
+	return &r
+}
+
+// ProbeStarted is called when a new probe was started
+func (reporter *Reporter) ProbeStarted(pathway string) {}
+
+// ProbeFinished is called when the probe has finished
+func (reporter *Reporter) ProbeFinished(report cerc.Report) {
+	reporter.reports[report.Pathway] = report
+}
+
+// Serve provides reports via HTTP
+func (reporter *Reporter) Serve(w http.ResponseWriter, r *http.Request) {
+
+	var (
+		msg []byte
+		err error
+	)
+
+	format := r.FormValue("format")
+	switch format {
+	case "raw":
+		msg, err = json.Marshal(reporter.reports)
+	case "json_flat":
+		msg, err = json.Marshal(reporter.summary(true))
+	default:
+		msg, err = json.Marshal(reporter.summary(false))
+	}
+
+	if err != nil {
+		fmt.Fprintln(w, "unexpected error", err)
+	} else {
+		fmt.Fprintln(w, string(msg))
+	}
+}
+
+func (reporter *Reporter) summary(flat bool) map[string]interface{} {
+	result := make(map[string]interface{})
+	result["status"] = "healthy"
+	for _, r := range reporter.reports {
+		if r.Result != cerc.ProbeSuccess {
+			result["status"] = "unhealthy"
+		}
+		var message interface{}
+		err := json.Unmarshal([]byte(r.Message), &message)
+		if err != nil {
+			message = r.Message
+		}
+		result[r.Pathway] = map[string]interface{}{
+			"result":    r.Result,
+			"message":   message,
+			"timestamp": r.Timestamp,
+		}
+	}
+	if flat {
+		result, _ = flatten.Flatten(result, "", flatten.DotStyle)
+		return result
+	}
+	return result
+}


### PR DESCRIPTION
Major contributions of this PR:
- Add a new reporter that provides a `/status` endpoint that delivers the latest results (bfad105).
- Allow to send data as body to the `/callback` endpoint (c86f13e).
- Allow to send a result (success/failure) to the `/callback` endpoint (e6f7b37).

Smaller contributions / fixes of this PR:
- Add `-h`, `--help`, `help` argument to CLI (7b7369b)
- Rename JSON field 'duration' to 'period' in Pathway (16f7ba7)
  This was quite confusing since I expected that this json field is called 'period' similar to 'defaultPeriod' but was called 'duration'. I guess this was not intended, thus fixed this.
- Runs the pathways at start up (4aa098b). Without this, the first run is after the timer fires the first time _after_ the period timestamp so we have to wait for the first result quite a long time.
- Add a timestamp to the report struct (3d202b9).
- Improve docker build (4ac106c)